### PR TITLE
Add PATH environment variable to Lambda function

### DIFF
--- a/lambda_app/lambda_app_stack.py
+++ b/lambda_app/lambda_app_stack.py
@@ -59,6 +59,7 @@ class LambdaAppStack(core.Stack):
             timeout=core.Duration.seconds(600),
             runtime=lambdas.Runtime.PYTHON_3_6,
             memory_size=512,
+            environment=dict(PATH="/opt"),
             role = role
         )
 


### PR DESCRIPTION
*Issue #1: Missing lambda environment variable PATH*

*Description of changes:*
Added PATH environment to Lambda function on lambda_app_stack.py file. Without it the function will fail with message:
`"Message: 'chromedriver' executable needs to be in PATH. Please see https://sites.google.com/a/chromium.org/chromedriver/home\n"`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
